### PR TITLE
refactor: set Logger class to open (SDKCF-4691)

### DIFF
--- a/sdk-utils/src/main/kotlin/com/rakuten/tech/mobile/sdkutils/logger/Logger.kt
+++ b/sdk-utils/src/main/kotlin/com/rakuten/tech/mobile/sdkutils/logger/Logger.kt
@@ -25,7 +25,7 @@ import kotlin.math.min
  *
  */
 @SuppressWarnings("TooManyFunctions", "SpreadOperator")
-class Logger(private val tag: String = "") {
+open class Logger(private val tag: String = "") {
 
     @SuppressWarnings("LongMethod", "ComplexMethod", "NestedBlockDepth")
     @Synchronized


### PR DESCRIPTION
# Description
Logs with empty tag are displayed only in the Android Studio's Run view and not in the Logcat view. 
Setting the `Logger.kt`class to open will allow overriding it to set a default Tag for all logs created in the host SDK.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
