### PR TITLE
improve: check preference key in shared preferences

### DIFF
--- a/sdk-utils/src/main/kotlin/com/rakuten/tech/mobile/sdkutils/PreferencesUtil.kt
+++ b/sdk-utils/src/main/kotlin/com/rakuten/tech/mobile/sdkutils/PreferencesUtil.kt
@@ -177,6 +177,17 @@ object PreferencesUtil {
         getSharedPreferences(context, name).edit().clear().apply()
     }
 
+    /**
+     * Checks whether the preferences contains a preference.
+     *
+     * @param key The name of the preference to check.
+     * @return Returns true if the preference exists in the preferences,
+     *         otherwise false.
+     */
+    fun contains(context: Context, name: String, key: String): Boolean {
+        return getSharedPreferences(context, name).contains(key)
+    }
+
     private fun getSharedPreferences(context: Context, name: String): SharedPreferences {
         return context.getSharedPreferences(name, Context.MODE_PRIVATE)
     }

--- a/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/PreferencesUtilSpec.kt
+++ b/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/PreferencesUtilSpec.kt
@@ -117,4 +117,16 @@ class PreferencesUtilSpec {
         PreferencesUtil.clear(context, sharedName)
         PreferencesUtil.getString(context, sharedName, "STRING", null) shouldBeEqualTo null
     }
+
+    @Test
+    fun `should check the key used in shared preferences`() {
+        PreferencesUtil.putInt(context, sharedName, "INT", 100)
+        PreferencesUtil.contains(context, sharedName, "INT") shouldBeEqualTo true
+    }
+
+    @Test
+    fun `should check the key if not used in shared preferences`() {
+        PreferencesUtil.putInt(context, sharedName, "INT", 100)
+        PreferencesUtil.contains(context, sharedName, "STRING") shouldBeEqualTo false
+    }
 }


### PR DESCRIPTION
# Description
To check a key whether exist or not in shared preferences

# Checklist
- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [ ] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
