### PR TITLE
refactor: Fix version conflicts with push sdk

### DIFF
--- a/sdk-utils/build.gradle
+++ b/sdk-utils/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   implementation 'com.squareup.retrofit2:retrofit:2.9.0'
   implementation 'com.google.code.gson:gson:2.8.9'
   implementation "com.google.code.gson:gson:$CONFIG.versions.thirdParty.gson"
-  implementation 'com.google.android.gms:play-services-base:17.0.0'
+  implementation 'com.google.android.gms:play-services-base:16.0.1'
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.robolectric:robolectric:4.3'

--- a/sdk-utils/build.gradle
+++ b/sdk-utils/build.gradle
@@ -26,12 +26,12 @@ android {
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$CONFIG.versions.kotlin"
   implementation "com.squareup.okhttp3:okhttp:$CONFIG.versions.okhttp"
-  compileOnly 'androidx.annotation:annotation:1.1.0'
+  compileOnly 'androidx.annotation:annotation:1.0.0'
   implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
   implementation 'com.squareup.retrofit2:retrofit:2.9.0'
   implementation 'com.google.code.gson:gson:2.8.9'
   implementation "com.google.code.gson:gson:$CONFIG.versions.thirdParty.gson"
-  implementation 'com.google.android.gms:play-services-base:18.0.1'
+  implementation 'com.google.android.gms:play-services-base:16.0.1'
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.robolectric:robolectric:4.3'

--- a/sdk-utils/build.gradle
+++ b/sdk-utils/build.gradle
@@ -26,12 +26,12 @@ android {
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$CONFIG.versions.kotlin"
   implementation "com.squareup.okhttp3:okhttp:$CONFIG.versions.okhttp"
-  implementation 'com.google.android.gms:play-services-base:17.0.0'
   compileOnly 'androidx.annotation:annotation:1.0.0'
   implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
   implementation 'com.squareup.retrofit2:retrofit:2.9.0'
   implementation 'com.google.code.gson:gson:2.8.9'
   implementation "com.google.code.gson:gson:$CONFIG.versions.thirdParty.gson"
+  implementation 'com.google.android.gms:play-services-base:17.0.0'
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.robolectric:robolectric:4.3'

--- a/sdk-utils/build.gradle
+++ b/sdk-utils/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   implementation 'com.squareup.retrofit2:retrofit:2.9.0'
   implementation 'com.google.code.gson:gson:2.8.9'
   implementation "com.google.code.gson:gson:$CONFIG.versions.thirdParty.gson"
-  implementation 'com.google.android.gms:play-services-base:16.0.1'
+  implementation 'com.google.android.gms:play-services-base:17.0.0'
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.robolectric:robolectric:4.3'

--- a/sdk-utils/build.gradle
+++ b/sdk-utils/build.gradle
@@ -26,12 +26,12 @@ android {
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$CONFIG.versions.kotlin"
   implementation "com.squareup.okhttp3:okhttp:$CONFIG.versions.okhttp"
+  implementation 'com.google.android.gms:play-services-base:17.0.0'
   compileOnly 'androidx.annotation:annotation:1.0.0'
   implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
   implementation 'com.squareup.retrofit2:retrofit:2.9.0'
   implementation 'com.google.code.gson:gson:2.8.9'
   implementation "com.google.code.gson:gson:$CONFIG.versions.thirdParty.gson"
-  implementation 'com.google.android.gms:play-services-base:16.0.1'
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.robolectric:robolectric:4.3'


### PR DESCRIPTION
# Description
Downgraded gms:play-services-base for consistent androidx:core versioning with Push SDK;
and also downgrade annotation version to fix strict versioning compile errors.

## Links
N/A

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [ ] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
