### PR TITLE
ci: add dependency checking to CI pipeline (SDKCF-4820)

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,6 +21,10 @@ workflows:
         inputs:
         - content: ./gradlew androidDependencies
     - script@1:
+        title: Dependency Check
+        inputs:
+        - content: ./gradlew dependencyCheckAggregate
+    - script@1:
         title: Run Check
         inputs:
         - content: ./gradlew check

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$CONFIG.versions.kotlin"
     classpath 'pl.allegro.tech.build:axion-release-plugin:1.10.2'
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+    classpath 'org.owasp:dependency-check-gradle:6.5.3'
   }
 }
 
@@ -41,4 +42,5 @@ allprojects { proj ->
   proj.version = scmVersion.version
 }
 
+apply from: "$project.rootDir/dependency-check.gradle"
 apply from: "$project.rootDir/sonar.gradle"

--- a/dependency-check.gradle
+++ b/dependency-check.gradle
@@ -1,0 +1,24 @@
+allprojects {
+    apply plugin: 'org.owasp.dependencycheck'
+
+    dependencyCheck {
+        skipProjects = [':sample']
+        // set the Common Vulnerability Scoring System value
+        // https://nvd.nist.gov/vuln-metrics/cvss
+        failBuildOnCVSS = System.getenv("DEPENDENCY_CHECK_FAILBUID_CVSS") as Integer
+        outputDirectory = 'build/reports/dependency-check'
+        formats = ['JSON', 'HTML']
+        showSummary true
+    }
+}
+
+subprojects { subproject ->
+    // skip dependencyCheck scan for sample apps
+    if( ['sample']
+            .contains(subproject.name)
+    ) {
+        dependencyCheck {
+            skip true
+        }
+    }
+}

--- a/dependency-check.gradle
+++ b/dependency-check.gradle
@@ -8,7 +8,6 @@ allprojects {
         failBuildOnCVSS = System.getenv("DEPENDENCY_CHECK_FAILBUID_CVSS") as Integer
         outputDirectory = 'build/reports/dependency-check'
         formats = ['JSON', 'HTML']
-        showSummary true
     }
 }
 

--- a/sonar.gradle
+++ b/sonar.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'org.sonarqube'
 
 def branch = System.getenv("BITRISE_GIT_BRANCH")
+def baseBranch = 'ci/dependency-check'
 
 sonarqube {
     properties {
@@ -10,12 +11,12 @@ sonarqube {
         property 'sonar.login', System.getenv("SONARQUBE_TOKEN")
         property 'sonar.projectKey', System.getenv("SONARQUBE_PROJ_KEY")
         property 'sonar.projectVersion', scmVersion.version
-        if (branch == "master" || branch == "") {
-            property 'sonar.branch.name', 'master'
+        if (branch == baseBranch || branch == "") {
+            property 'sonar.branch.name', baseBranch
         } else {
             property 'sonar.pullrequest.key', System.getenv("BITRISE_PULL_REQUEST").findAll(/\d+/)*.toInteger().last()
             property 'sonar.pullrequest.branch', branch
-            property 'sonar.pullrequest.base', 'master'
+            property 'sonar.pullrequest.base', baseBranch
         }
         property 'sonar.qualitygate.wait', true
     }
@@ -35,6 +36,11 @@ subprojects { subproject ->
             property 'sonar.test.inclusions', '**/test/**'
             property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/jacocoReleaseReport/jacocoReleaseReport.xml'
             property 'sonar.junit.reportPaths', 'build/test-results/testReleaseUnitTest'
+
+            /* Dependency Check */
+            property 'sonar.dependencyCheck.skip', System.getenv("SONAR_DEPENDENCYCHECK_SKIP")
+            property 'sonar.dependencyCheck.jsonReportPath', 'build/reports/dependency-check/dependency-check-report.json'
+            property 'sonar.dependencyCheck.htmlReportPath', 'build/reports/dependency-check/dependency-check-report.html'
         }
     }
 }

--- a/sonar.gradle
+++ b/sonar.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'org.sonarqube'
 
 def branch = System.getenv("BITRISE_GIT_BRANCH")
-def baseBranch = 'ci/dependency-check'
+def baseBranch = 'master'
 
 sonarqube {
     properties {
@@ -19,6 +19,11 @@ sonarqube {
             property 'sonar.pullrequest.base', baseBranch
         }
         property 'sonar.qualitygate.wait', true
+
+        /* Dependency Check */
+        property 'sonar.dependencyCheck.skip', System.getenv("SONAR_DEPENDENCYCHECK_SKIP")
+        property 'sonar.dependencyCheck.jsonReportPath', 'build/reports/dependency-check/dependency-check-report.json'
+        property 'sonar.dependencyCheck.htmlReportPath', 'build/reports/dependency-check/dependency-check-report.html'
     }
 }
 
@@ -36,11 +41,6 @@ subprojects { subproject ->
             property 'sonar.test.inclusions', '**/test/**'
             property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/jacocoReleaseReport/jacocoReleaseReport.xml'
             property 'sonar.junit.reportPaths', 'build/test-results/testReleaseUnitTest'
-
-            /* Dependency Check */
-            property 'sonar.dependencyCheck.skip', System.getenv("SONAR_DEPENDENCYCHECK_SKIP")
-            property 'sonar.dependencyCheck.jsonReportPath', 'build/reports/dependency-check/dependency-check-report.json'
-            property 'sonar.dependencyCheck.htmlReportPath', 'build/reports/dependency-check/dependency-check-report.html'
         }
     }
 }


### PR DESCRIPTION
Dependency checking will be included in the build job. It will fail the build if any Vulnerability is detected.

For now DEPENDENCY_CHECK_FAILBUID_CVSS = 11 and SONAR_DEPENDENCYCHECK_SKIP = true to not fail the build (until we fix detected Vulnerabilities).

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [ ] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
