### PR TITLE
improve: update the content provider's init-order to high value (SDKCF-5292)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,20 @@ dependency {
 
 ### 2. Set initialization order (optional)
 
-You only need to set this if you are facing an Exception when trying to use features of this SDK at launch time.
-
-This SDK uses a `ContentProvider` in order to automatically initialize. If you are also using a ContentProvider in your App
-or you are developing an SDK which uses a ContentProvider to automatically initialize, then you may need to manually set the
+⚠️  This SDK uses a `ContentProvider` in order to automatically initialize. It is not recommended to override the default value set for `initOrder`. 
+However, you may need to set it if you are facing an Exception when trying to use features of this SDK at launch time. If you are also using a ContentProvider in your App or you are developing an SDK which uses a ContentProvider to automatically initialize, then you may need to manually set the
 `initOrder` for this SDK so that it is initialized first. This can be set in `AndroidManifest.xml`:
 
 ```xml
   <application>
-    <!-- The `initOrder` for this SDK is set to `99` by default. -->
-    <!-- Set it to something higher to make it initialize before your own ContentProvider. -->
+    <!-- The `initOrder` for this SDK is set to `9999` by default. -->
+    <!-- ⚠️ It is not recommended to override the `initOrder`, however, if you need to manually set it, make sure that it is initialized before your own ContentProvider. -->
     <provider
       tools:replace="android:initOrder"
       android:name="com.rakuten.tech.mobile.sdkutils.SdkUtilsInitProvider"
       android:authorities="${applicationId}.SdkUtilsInitProvider"
       android:exported="false"
-      android:initOrder="100" />
+      android:initOrder="9999" />
   </application>
 ```
 
@@ -226,6 +224,9 @@ val retrofit = Retrofit.Builder().build("your_baseUrl", okHttpClient gsonConvert
 </ul>
 
 ## Changelog
+
+### v1.2.0 (in progress)
+* SDKCF-5292: Set initOrder of the content provider to a high value to make sure that it is initialized before the host app ContentProvider.
 
 ### v1.1.0 (2022-03-17)
 

--- a/sdk-utils/src/main/AndroidManifest.xml
+++ b/sdk-utils/src/main/AndroidManifest.xml
@@ -3,10 +3,13 @@
   xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
+    <!-- It is not recommended to override the `initOrder`, however,
+    if you need to manually set it, make sure that it is initialized before your own
+    ContentProvider. -->
     <provider
       android:name="com.rakuten.tech.mobile.sdkutils.SdkUtilsInitProvider"
       android:authorities="${applicationId}.SdkUtilsInitProvider"
       android:exported="false"
-      android:initOrder="99" />
+      android:initOrder="9999" />
   </application>
 </manifest>


### PR DESCRIPTION
# Description
Update the `initOrder` of `SdkUtilsInitProvider` to a high value (9999), to avoid SDK dependency order affecting the initialization order

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
