### PR TITLE
refactor: revert static API and change to deprecated to avoid crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ val retrofit = Retrofit.Builder().build("your_baseUrl", okHttpClient gsonConvert
 
 ### v2.0.0 (in-progress)
 * SDKCF-5390: **Breaking Changes:** Moved `setDebugLevel()` and `setDebug()` APIs from static to `Logger` class APIs. This will allow multiple SDK app dependencies to have their own debug logging configuration.
+  - Deprecated `Logger.setDebugLevel()` and `Logger.setDebug()` static APIs. These APIs will no longer work but not removed to avoid crashes on incompatible SDK versions.
 
 ### v1.2.0 (2022-05-19)
 * SDKCF-5292: Set initOrder of the content provider to a high value to make sure that it is initialized before the host app ContentProvider.

--- a/sdk-utils/src/main/kotlin/com/rakuten/tech/mobile/sdkutils/logger/Logger.kt
+++ b/sdk-utils/src/main/kotlin/com/rakuten/tech/mobile/sdkutils/logger/Logger.kt
@@ -199,5 +199,26 @@ open class Logger(private val tag: String = "") {
     companion object {
         private const val MAX_LOG_LENGTH = 4000
         private const val INITIAL_SIZE = 256
+
+        /**
+         * This method enables/disables debug logger.
+         * By default only info, warn and error are logged. Debug is only logged
+         * if [Logger.setDebug] is called with `true`.
+         * @param debug true to enable debug, false otherwise
+         */
+        @Deprecated("Using this method will have no effect.",
+            ReplaceWith("`loggerInstance.setDebug(<true/false>)`"))
+        fun setDebug(debug: Boolean) = Unit
+
+        /**
+         * Set the level of the stack trace line to be logged.
+         * The element at the top of the stack (stackFramePosition = 0) represents the execution
+         * point at which the stack trace was generated.
+         *
+         * @param stackFramePosition the position of the stack trace element to be logged.
+         */
+        @Deprecated("Using this method will have no effect.",
+            ReplaceWith("`loggerInstance.setDebugLevel(<value>)`"))
+        fun setDebugLevel(stackFramePosition: Int) = Unit
     }
 }

--- a/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/logger/LoggerSpec.kt
+++ b/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/logger/LoggerSpec.kt
@@ -35,6 +35,13 @@ class LoggerSpec {
     }
 
     @Test
+    fun `should not enable debug in set debug static api`() {
+        Logger.setDebug(true)
+        logger.debug("some debug log")
+        assertThatLog().hasNoMoreMessages()
+    }
+
+    @Test
     fun `should enable debug and verbose logging in set debug`() {
         logger.setDebug(true)
         logger.debug("some debug log")
@@ -115,6 +122,10 @@ class LoggerSpec {
         assertThatLog().hasMessage(Log.DEBUG, TAG, "test")
 
         logger.setDebugLevel(-1)
+        logger.debug(Throwable(), "test")
+        assertThatLog().hasMessage(Log.DEBUG, TAG, "test")
+
+        Logger.setDebugLevel(100)
         logger.debug(Throwable(), "test")
         assertThatLog().hasMessage(Log.DEBUG, TAG, "test")
     }


### PR DESCRIPTION
# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
