### PR TITLE
improve: create Github release version (SDKCF-5386)

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -66,6 +66,8 @@ workflows:
   release:
     before_run:
     - build-and-test
+    after_run:
+    - _create-github-release
     steps:
     - script@1:
         title: Retrieve Base64 PGP Key and save to file
@@ -127,6 +129,23 @@ workflows:
         title: Run SonarQube Scanner
         inputs:
         - content: ./gradlew sonarqube
+  _create-github-release:
+    steps:
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            _CHANGELOG="${GIT_REPOSITORY_URL%.git}/tree/$BITRISE_GIT_TAG#changelog"
+            envman add --key CHANGELOG --value "$_CHANGELOG"
+    - github-release@0.11.0:
+        inputs:
+        - body: "$CHANGELOG"
+        - draft: 'no'
+        - username: "$PUBLISHER_GITHUB_USERNAME"
+        - api_token: "$PUBLISHER_GITHUB_API_TOKEN"
+        - name: "$BITRISE_GIT_TAG"
 meta:
   bitrise.io:
     stack: linux-docker-android-20.04

--- a/dependency_check_suppressions.xml
+++ b/dependency_check_suppressions.xml
@@ -268,6 +268,7 @@
     <cve>CVE-2022-38752</cve>
     <cve>CVE-2022-41854</cve>
     <cve>CVE-2022-38750</cve>
+    <cve>CVE-2022-1471</cve>
   </suppress>
   <suppress until="2022-12-31Z">
     <notes><![CDATA[

--- a/dependency_check_suppressions.xml
+++ b/dependency_check_suppressions.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: ant-1.8.0.jar
    ]]></notes>
     <sha1>7b456ca6b93900f96e58cc8371f03d90a9c1c8d1</sha1>
     <cve>CVE-2020-1945</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: ant-launcher-1.8.0.jar
    ]]></notes>
     <sha1>08b53ba16fa62fb1034da8f1de200ddc407c8381</sha1>
     <cve>CVE-2020-1945</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: bcprov-jdk15on-1.52.jar
    ]]></notes>
@@ -33,7 +33,7 @@
     <cve>CVE-2020-15522</cve>
     <cve>CVE-2020-26939</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: bcprov-jdk15on-1.56.jar
    ]]></notes>
@@ -44,7 +44,7 @@
     <cve>CVE-2020-15522</cve>
     <cve>CVE-2020-26939</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: builder-4.0.2.jar: desugar_deploy.jar (shaded: com.google.guava:guava:21.0)
    ]]></notes>
@@ -52,70 +52,70 @@
     <cve>CVE-2018-10237</cve>
     <cve>CVE-2020-8908</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: checkstyle-8.18.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.puppycrawl\.tools/checkstyle@.*$</packageUrl>
     <cve>CVE-2019-10782</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: commons-beanutils-1.9.3.jar
    ]]></notes>
     <cve>CVE-2014-0114</cve>
     <cve>CVE-2019-10086</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: detekt-api-1.1.1.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.gitlab\.arturbosch\.detekt/detekt\-api@.*$</packageUrl>
     <cve>CVE-2022-0272</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: detekt-api-1.16.0.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.gitlab\.arturbosch\.detekt/detekt\-api@.*$</packageUrl>
     <cve>CVE-2022-0272</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: detekt-cli-1.1.1.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.gitlab\.arturbosch\.detekt/detekt\-cli@.*$</packageUrl>
     <cve>CVE-2022-0272</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: detekt-core-1.1.1.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.gitlab\.arturbosch\.detekt/detekt\-core@.*$</packageUrl>
     <cve>CVE-2022-0272</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: detekt-formatting-1.16.0.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.gitlab\.arturbosch\.detekt/detekt\-formatting@.*$</packageUrl>
     <cve>CVE-2022-0272</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: detekt-psi-utils-1.16.0.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.gitlab\.arturbosch\.detekt/detekt\-psi\-utils@.*$</packageUrl>
     <cve>CVE-2022-0272</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: detekt-rules-1.1.1.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.gitlab\.arturbosch\.detekt/detekt\-rules@.*$</packageUrl>
     <cve>CVE-2022-0272</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: full.jar (project :sdk-utils)
    ]]></notes>
@@ -124,7 +124,7 @@
     <cve>CVE-2020-10518</cve>
     <cve>CVE-2020-10519</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: kotlin-compiler-embeddable-1.3.50.jar
    ]]></notes>
@@ -132,14 +132,14 @@
     <cve>CVE-2020-29582</cve>
     <cve>CVE-2022-24329</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: kotlin-compiler-embeddable-1.4.21.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-compiler\-embeddable@.*$</packageUrl>
     <cve>CVE-2022-24329</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: kotlin-daemon-embeddable-1.3.50.jar
    ]]></notes>
@@ -147,14 +147,14 @@
     <cve>CVE-2020-29582</cve>
     <cve>CVE-2022-24329</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: kotlin-daemon-embeddable-1.4.21.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-daemon\-embeddable@.*$</packageUrl>
     <cve>CVE-2022-24329</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: kotlin-reflect-1.3.50.jar
    ]]></notes>
@@ -162,14 +162,14 @@
     <cve>CVE-2020-29582</cve>
     <cve>CVE-2022-24329</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: kotlin-reflect-1.4.21.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-reflect@.*$</packageUrl>
     <cve>CVE-2022-24329</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: kotlin-script-runtime-1.3.50.jar
    ]]></notes>
@@ -177,14 +177,14 @@
     <cve>CVE-2020-29582</cve>
     <cve>CVE-2022-24329</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: kotlin-script-runtime-1.4.21.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-script\-runtime@.*$</packageUrl>
     <cve>CVE-2022-24329</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: kotlin-stdlib-1.3.50.jar
    ]]></notes>
@@ -192,14 +192,14 @@
     <cve>CVE-2020-29582</cve>
     <cve>CVE-2022-24329</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: kotlin-stdlib-1.4.21.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib@.*$</packageUrl>
     <cve>CVE-2022-24329</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: kotlin-stdlib-common-1.3.50.jar
    ]]></notes>
@@ -207,81 +207,88 @@
     <cve>CVE-2020-29582</cve>
     <cve>CVE-2022-24329</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: kotlin-stdlib-common-1.4.21.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib\-common@.*$</packageUrl>
     <cve>CVE-2022-24329</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: maven-ant-tasks-2.1.3.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.maven/maven\-ant\-tasks@.*$</packageUrl>
     <cve>CVE-2020-22475</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: maven-artifact-manager-2.2.1.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.maven/maven\-artifact\-manager@.*$</packageUrl>
     <vulnerabilityName>CVE-2021-26291</vulnerabilityName>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: nekohtml-1.9.6.2.jar
    ]]></notes>
     <sha1>2d960be7b62ae6622dbbbe49ab4ffdc609f85c80</sha1>
     <cve>CVE-2022-24839</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: okhttp-3.14.9.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.squareup\.okhttp3/okhttp@.*$</packageUrl>
     <vulnerabilityName>CVE-2021-0341</vulnerabilityName>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: plexus-utils-1.5.15.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-utils@.*$</packageUrl>
     <cve>CVE-2017-1000487</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: protobuf-java-2.6.1.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/protobuf\-java@.*$</packageUrl>
     <cve>CVE-2021-22569</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: snakeyaml-1.24.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
     <cve>CVE-2017-18640</cve>
+    <cve>CVE-2022-25857</cve>
+    <cve>CVE-2022-38749</cve>
+    <cve>CVE-2022-38751</cve>
+    <cve>CVE-2022-38752</cve>
+    <cve>CVE-2022-41854</cve>
+    <cve>CVE-2022-38750</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: kotlin-annotation-processing-gradle-1.6.21.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-annotation\-processing\-gradle@.*$</packageUrl>
     <cve>CVE-2018-1000840</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: sarif4k-0.0.1.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.github\.detekt\.sarif4k/sarif4k@.*$</packageUrl>
     <cve>CVE-2022-0272</cve>
   </suppress>
-  <suppress until="2022-09-30Z">
+  <suppress until="2022-12-31Z">
     <notes><![CDATA[
    file name: play-services-basement-17.0.0.aar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.google\.android\.gms/play\-services\-basement@.*$</packageUrl>
     <vulnerabilityName>CVE-2022-1799</vulnerabilityName>
+    <vulnerabilityName>CVE-2022-2390</vulnerabilityName>
   </suppress>
 </suppressions>


### PR DESCRIPTION
Uses the plugin `steps-github-release` to automate Github release.
Limitation: Overriding release not yet supported (to-be): https://github.com/bitrise-steplib/steps-github-release/issues/5
In case there's a need to re-tag and a release is already published (should be a rare scenario), first delete the [release](https://github.com/rakutentech/android-sdkutils/releases).