### PR TITLE
tests: fix local failing tests for `CommonUtil`

### DIFF
--- a/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/CommonUtilSpec.kt
+++ b/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/CommonUtilSpec.kt
@@ -23,7 +23,9 @@ class CommonUtilSpec {
     @Test
     @Config(sdk = [Build.VERSION_CODES.M])
     fun `should get UTC date format for android 23`() {
-        val simpleDateFormat = SimpleDateFormat("dd.MM.yyyy HH:mm:ss", Locale.JAPAN)
+        val simpleDateFormat = SimpleDateFormat("dd.MM.yyyy HH:mm:ss").apply {
+            timeZone = TimeZone.getTimeZone("JST")
+        }
         val date = simpleDateFormat.parse("02.04.2014 15:00:00")
         val isoFormattedDate = CommonUtil.getUTCDateFormat().format(date!!)
         isoFormattedDate shouldBeEqualTo "2014-04-02T06:00:00"

--- a/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/CommonUtilSpec.kt
+++ b/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/CommonUtilSpec.kt
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.text.SimpleDateFormat
+import java.util.*
 
 @RunWith(RobolectricTestRunner::class)
 class CommonUtilSpec {
@@ -22,8 +23,8 @@ class CommonUtilSpec {
     @Test
     @Config(sdk = [Build.VERSION_CODES.M])
     fun `should get UTC date format for android 23`() {
-        val simpleDateFormat = SimpleDateFormat("dd.MM.yyyy HH:mm:ss")
-        val date = simpleDateFormat.parse("02.04.2014 15:00:00+09")
+        val simpleDateFormat = SimpleDateFormat("dd.MM.yyyy HH:mm:ss", Locale.JAPAN)
+        val date = simpleDateFormat.parse("02.04.2014 15:00:00")
         val isoFormattedDate = CommonUtil.getUTCDateFormat().format(date!!)
         isoFormattedDate shouldBeEqualTo "2014-04-02T06:00:00"
     }

--- a/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/CommonUtilSpec.kt
+++ b/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/CommonUtilSpec.kt
@@ -5,25 +5,26 @@ import org.amshove.kluent.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.util.ReflectionHelpers
+import org.robolectric.annotation.Config
 import java.text.SimpleDateFormat
 
 @RunWith(RobolectricTestRunner::class)
 class CommonUtilSpec {
     @Test
+    @Config(sdk = [Build.VERSION_CODES.N])
     fun `should get UTC date format`() {
-        val simpleDateFormat = SimpleDateFormat("dd.MM.yyyy HH:mm:ss")
-        val date = simpleDateFormat.parse("02.04.2014 15:00:00")
+        val simpleDateFormat = SimpleDateFormat("dd.MM.yyyy HH:mm:ssX")
+        val date = simpleDateFormat.parse("02.04.2014 15:00:00+09")
         val isoFormattedDate = CommonUtil.getUTCDateFormat().format(date!!)
-        isoFormattedDate shouldBeEqualTo "2014-04-02T15:00:00Z"
+        isoFormattedDate shouldBeEqualTo "2014-04-02T06:00:00Z"
     }
 
     @Test
+    @Config(sdk = [Build.VERSION_CODES.M])
     fun `should get UTC date format for android 23`() {
-        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 23)
-        val simpleDateFormat = SimpleDateFormat("dd.MM.yyyy HH:mm:ss")
-        val date = simpleDateFormat.parse("02.04.2014 15:00:00")
+        val simpleDateFormat = SimpleDateFormat("dd.MM.yyyy HH:mm:ssX")
+        val date = simpleDateFormat.parse("02.04.2014 15:00:00+09")
         val isoFormattedDate = CommonUtil.getUTCDateFormat().format(date!!)
-        isoFormattedDate shouldBeEqualTo "2014-04-02T15:00:00"
+        isoFormattedDate shouldBeEqualTo "2014-04-02T06:00:00"
     }
 }

--- a/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/CommonUtilSpec.kt
+++ b/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/CommonUtilSpec.kt
@@ -22,7 +22,7 @@ class CommonUtilSpec {
     @Test
     @Config(sdk = [Build.VERSION_CODES.M])
     fun `should get UTC date format for android 23`() {
-        val simpleDateFormat = SimpleDateFormat("dd.MM.yyyy HH:mm:ssX")
+        val simpleDateFormat = SimpleDateFormat("dd.MM.yyyy HH:mm:ss")
         val date = simpleDateFormat.parse("02.04.2014 15:00:00+09")
         val isoFormattedDate = CommonUtil.getUTCDateFormat().format(date!!)
         isoFormattedDate shouldBeEqualTo "2014-04-02T06:00:00"


### PR DESCRIPTION
Running tests locally will fail as `SimpleDateFormat` will use machine's timezone. CI is probably in `UTC` format so no issues are encountered.
Explicitly specify the timezone to work with any machine.