### PR TITLE
refactor: require API key and URL in `EventLogger` configure

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -13,6 +13,11 @@ android {
     versionCode 1
     versionName "1.0"
     minSdkVersion 23
+
+    buildConfigField("String", "EVENT_LOGGER_API_URL_PRD", "\"${property("EVENT_LOGGER_API_URL_PRD")}\"")
+    buildConfigField("String", "EVENT_LOGGER_API_URL_STG", "\"${property("EVENT_LOGGER_API_URL_STG")}\"")
+    buildConfigField("String", "EVENT_LOGGER_API_KEY_PRD", "\"${property("EVENT_LOGGER_API_KEY_PRD")}\"")
+    buildConfigField("String", "EVENT_LOGGER_API_KEY_STG", "\"${property("EVENT_LOGGER_API_KEY_STG")}\"")
   }
 
   sourceSets.each {
@@ -43,10 +48,18 @@ android {
   }
 
   buildTypes {
+    debug {
+      buildConfigField("String", "EVENT_LOGGER_API_URL", "\"${property("EVENT_LOGGER_API_URL_STG")}\"")
+      buildConfigField("String", "EVENT_LOGGER_API_KEY", "\"${property("EVENT_LOGGER_API_KEY_STG")}\"")
+    }
+
     release {
       minifyEnabled true
       debuggable false
       signingConfig signingConfigs.release
+
+      buildConfigField("String", "EVENT_LOGGER_API_URL", "\"${property("EVENT_LOGGER_API_URL_PRD")}\"")
+      buildConfigField("String", "EVENT_LOGGER_API_KEY", "\"${property("EVENT_LOGGER_API_KEY_PRD")}\"")
     }
   }
 }

--- a/sample/src/main/kotlin/com/rakuten/tech/mobile/sdkutils/sample/EventLoggerActivity.kt
+++ b/sample/src/main/kotlin/com/rakuten/tech/mobile/sdkutils/sample/EventLoggerActivity.kt
@@ -28,8 +28,7 @@ class EventLoggerActivity : AppCompatActivity() {
         binding.activity = this
         setDefaultsOrHints()
 
-        // EventLogger: use default API Key+URL
-        EventLogger.configure(this)
+        EventLogger.configure(this, BuildConfig.EVENT_LOGGER_API_URL, BuildConfig.EVENT_LOGGER_API_KEY)
     }
 
     @SuppressWarnings("LongMethod")

--- a/sdk-utils/build.gradle
+++ b/sdk-utils/build.gradle
@@ -4,10 +4,6 @@ apply plugin: "kotlin-android"
 apply plugin: 'kotlin-kapt'
 
 android {
-  def property = { key ->
-    return System.getenv(key) ?: (project.hasProperty(key) ? project."$key" : "")
-  }
-
   defaultConfig {
     consumerProguardFiles "proguard-rules.pro"
     resValue 'string', 'sdk_utils__version', project.version

--- a/sdk-utils/build.gradle
+++ b/sdk-utils/build.gradle
@@ -11,11 +11,6 @@ android {
   defaultConfig {
     consumerProguardFiles "proguard-rules.pro"
     resValue 'string', 'sdk_utils__version', project.version
-
-    buildConfigField("String", "EVENT_LOGGER_API_URL_PRD", "\"${property("EVENT_LOGGER_API_URL_PRD")}\"")
-    buildConfigField("String", "EVENT_LOGGER_API_URL_STG", "\"${property("EVENT_LOGGER_API_URL_STG")}\"")
-    buildConfigField("String", "EVENT_LOGGER_API_KEY_PRD", "\"${property("EVENT_LOGGER_API_KEY_PRD")}\"")
-    buildConfigField("String", "EVENT_LOGGER_API_KEY_STG", "\"${property("EVENT_LOGGER_API_KEY_STG")}\"")
   }
 
   lintOptions {
@@ -34,18 +29,6 @@ android {
 
   kotlinOptions {
     jvmTarget = JavaVersion.toVersion(CONFIG.versions.java).toString()
-  }
-
-  buildTypes {
-    debug {
-      buildConfigField("String", "EVENT_LOGGER_API_URL", "\"${property("EVENT_LOGGER_API_URL_STG")}\"")
-      buildConfigField("String", "EVENT_LOGGER_API_KEY", "\"${property("EVENT_LOGGER_API_KEY_STG")}\"")
-    }
-
-    release {
-      buildConfigField("String", "EVENT_LOGGER_API_URL", "\"${property("EVENT_LOGGER_API_URL_PRD")}\"")
-      buildConfigField("String", "EVENT_LOGGER_API_KEY", "\"${property("EVENT_LOGGER_API_KEY_PRD")}\"")
-    }
   }
 }
 

--- a/sdk-utils/src/main/kotlin/com/rakuten/tech/mobile/sdkutils/eventlogger/EventLogger.kt
+++ b/sdk-utils/src/main/kotlin/com/rakuten/tech/mobile/sdkutils/eventlogger/EventLogger.kt
@@ -38,26 +38,26 @@ object EventLogger {
      * `onCreate` or other initialization methods.
      *
      * @param context Application context.
-     * @param apiUrl Optional API URL that will override the default configuration.
-     * @param apiKey Optional API Key that will override the default configuration.
+     * @param apiUrl Server API URL.
+     * @param apiKey Server API Key.
      */
     @Synchronized
     fun configure(
         context: Context,
-        apiUrl: String? = null,
-        apiKey: String? = null
+        apiUrl: String,
+        apiKey: String
     ) {
         if (isConfigureCalled) {
             log.debug("Event Logger has been configured already")
             return
         }
 
-        val (realApiUrl, realApiKey) = if (!apiUrl.isNullOrEmpty() && !apiKey.isNullOrEmpty()) {
-            Pair(apiUrl, apiKey)
-        } else {
-            Pair(Config.EVENT_LOGGER_BASE_URL, Config.EVENT_LOGGER_API_KEY)
+        if (apiUrl.isEmpty() || apiKey.isEmpty()) {
+            log.warn("Event Logger cannot be configured due to empty API URL or key")
+            return
         }
-        initialize(context, realApiUrl, realApiKey)
+
+        initialize(context, apiUrl, apiKey)
     }
 
     /**
@@ -302,8 +302,6 @@ object EventLogger {
     internal object Config {
         const val MAX_EVENTS_COUNT = 50
         const val TTL_EXPIRY_MILLIS = 3600 * 1000 * 12 // 12 hours
-        const val EVENT_LOGGER_BASE_URL = BuildConfig.EVENT_LOGGER_API_URL
-        const val EVENT_LOGGER_API_KEY = BuildConfig.EVENT_LOGGER_API_KEY
         const val EVENTS_STORAGE_FILENAME = "${BuildConfig.LIBRARY_PACKAGE_NAME}.eventlogger.events"
         const val EVENT_LOGGER_GENERAL_CACHE_FILENAME = "${BuildConfig.LIBRARY_PACKAGE_NAME}.eventlogger.cache"
     }

--- a/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/eventlogger/EventLoggerSpec.kt
+++ b/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/eventlogger/EventLoggerSpec.kt
@@ -156,7 +156,7 @@ class ConfigureSpec : EventLoggerSpec() {
     @Test
     fun `1 - should configure only once`() {
         EventLogger.configure(mockContext, "https://test", "abcd")
-        EventLogger.configure(mockContext)
+        EventLogger.configure(mockContext, "https://test2", "wxyz")
 
         verify(mockContext, times(1)).getSharedPreferences(
             EventLogger.Config.EVENTS_STORAGE_FILENAME,

--- a/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/eventlogger/EventLoggerSpec.kt
+++ b/sdk-utils/src/test/kotlin/com/rakuten/tech/mobile/sdkutils/eventlogger/EventLoggerSpec.kt
@@ -155,6 +155,7 @@ class ConfigureSpec : EventLoggerSpec() {
 
     @Test
     fun `1 - should configure only once`() {
+        EventLogger.configure(mockContext, "", "")
         EventLogger.configure(mockContext, "https://test", "abcd")
         EventLogger.configure(mockContext, "https://test2", "wxyz")
 


### PR DESCRIPTION
# Description
* Offload configuration from sdk-utils for security purposes, and iOS alignment
* `EventLogger` is planned to be configured via RMC

## Links
N/A

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
