### PR TITLE
improve: add error message randomizer and events cache count in `EventLogger` sample app

### DIFF
--- a/sample/src/main/kotlin/com/rakuten/tech/mobile/sdkutils/sample/EventLoggerCacheActivity.kt
+++ b/sample/src/main/kotlin/com/rakuten/tech/mobile/sdkutils/sample/EventLoggerCacheActivity.kt
@@ -29,12 +29,14 @@ class EventLoggerCacheActivity : AppCompatActivity() {
     private fun setCacheText() {
 
         if (eventsCache.all.isEmpty()) {
-            binding.eventsStorageText.text = "<empty>"
+            binding.numEventsLabel.text = "Count: 0"
             return
         }
 
         val textBuilder = StringBuilder(0)
-        for (event in eventsCache.all) {
+        val allEvents = eventsCache.all
+        binding.numEventsLabel.text = "Count: ${allEvents.size}"
+        for (event in allEvents) {
             textBuilder.append(event.key)
             textBuilder.append("\n")
             textBuilder.append(

--- a/sample/src/main/res/layout/activity_event_logger.xml
+++ b/sample/src/main/res/layout/activity_event_logger.xml
@@ -224,6 +224,19 @@
                 android:layout_height="wrap_content" >
 
                 <Button
+                    android:id="@+id/log_unique_events"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold"
+                    android:text="Log Unique Event/s\n(randomize Error Message)"
+                    android:onClick="@{() -> activity.onLogUniqueEventButtonClick()}" />
+            </TableRow>
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" >
+
+                <Button
                     android:id="@+id/show_events_cache"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/sample/src/main/res/layout/activity_event_logger_cache.xml
+++ b/sample/src/main/res/layout/activity_event_logger_cache.xml
@@ -8,9 +8,18 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" >
 
+        <TextView
+            android:id="@+id/num_events_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:textSize="20dp"
+            tools:text="Count: XXX" />
+
         <ScrollView
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:layout_below="@id/num_events_label" >
 
             <TextView
                 android:id="@+id/events_storage_text"


### PR DESCRIPTION
# Description
Updated sample app for testing
* Added errorMessage randomizer
* Displayed events count in storage

## Links
N/A

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [ ] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [X] I tested non-trivial changes on a real device
- [X] I ran `./gradlew check` without errors
